### PR TITLE
Added CSS styling for active sidebar menu hover text color

### DIFF
--- a/src/scss/_sidebar.scss
+++ b/src/scss/_sidebar.scss
@@ -116,7 +116,7 @@
     }
 
     &-item.active {
-      @apply text-primary-500;
+      @apply text-primary-500 dark:hover:text-white;
     }
   }
 


### PR DESCRIPTION
** Description **

While hovering over the active sidebar menu in dark mode, the text color was blending with the background, making it difficult to view. I've addressed this CSS issue by enhancing the hover text color, ensuring better visibility and usability.

<img width="1512" alt="Screenshot 2024-01-03 at 9 32 30 PM" src="https://github.com/mostafizurhimself/admintoolkit-html/assets/38912435/7d7a477d-0814-45f1-bda2-bd15ba1955f1">

<img width="1512" alt="Screenshot 2024-01-03 at 9 31 15 PM" src="https://github.com/mostafizurhimself/admintoolkit-html/assets/38912435/335f1996-85fc-47ae-8dec-437eec00b5c0">

